### PR TITLE
Fixed min_len calculation

### DIFF
--- a/jellyfish/_jellyfish.py
+++ b/jellyfish/_jellyfish.py
@@ -43,7 +43,7 @@ def _jaro_winkler(ying, yang, long_tolerance, winklerize):
     if not ying_len or not yang_len:
         return 0
 
-    min_len = max(ying_len, yang_len)
+    min_len = min(ying_len, yang_len)
     search_range = (min_len // 2) - 1
     if search_range < 0:
         search_range = 0


### PR DESCRIPTION
According to the variable name, I believe this was the real intention.
also, when the jaro_winkler function was called with two similar strings with different lengths (I.E - "William", "Williams") it threw an exception.
This small change fixes that.
